### PR TITLE
Restructure spec so as to not hard-code URLs

### DIFF
--- a/jdk/redhat/src/main/packaging/temurin/11/README
+++ b/jdk/redhat/src/main/packaging/temurin/11/README
@@ -1,0 +1,104 @@
+RPM installers (Fedora/Red Hat)
+-------------------------------
+
+This is an example spec file which can be used to produce an SRPM and rebuild
+that SRPM into a binary RPM. It supports building it for the current target
+architecture or for a different one that the host system by specifying 'vers_arch'.
+
+Different JVM types are supported by using the '--with openj9' RPM conditional
+switch.
+
+Prequisites:
+
+'rpm-build' and 'rpmdevtools' packages are installed.
+
+
+Produce a source/binary RPM for Hotspot x86_64:
+-----------------------------------------------
+
+Consider this Hotspot RPM build where x86_64 is the build hosts'
+architecture.
+
+$ spec=$(pwd)/temurin-jdk-11.spec
+$ mkdir hotspot_x86_64
+$ pushd hotspot_x86_64
+$ spectool --gf ${spec}
+
+Currently fails due to typo (uppercase 'U') in sha256.txt files
+
+$ sha256sum -c *.sha256.txt
+
+Create an SRPM
+
+$ rpmbuild --define "_sourcedir $(pwd)" --define "_specdir $(pwd)" \
+           --define "_builddir $(pwd)" --define "_srcrpmdir $(pwd)" \
+           --define "_rpmdir $(pwd)" --nodeps -bs ${spec}
+
+Build the binary from the SRPM
+
+$ rpmbuild --define "_sourcedir $(pwd)" --define "_specdir $(pwd)" \
+           --define "_builddir $(pwd)" --define "_srcrpmdir $(pwd)" \
+           --define "_rpmdir $(pwd)" --rebuild *.src.rpm
+
+
+OpenJ9 s390x (on x86_64 host):
+------------------------------
+
+In order to produce RPMs on an x86_64 build host for the s390x
+target architecture and the OpenJ9 JVM, consider this example.
+
+$ spec=$(pwd)/temurin-jdk-11.spec
+$ mkdir openj9_s390x
+$ pushd openj9_s390x
+$ spectool --define '_with_openj9 --with-openj9' \
+           --define 'vers_arch s390x' \
+           --gf ${spec}.spec
+
+Currently fails due to typo (uppercase 'U') in sha256.txt files
+
+$ sha256sum -c *.sha256.txt
+
+Create an SRPM
+
+$ rpmbuild --with openj9 --define 'vers_arch s390x' \
+           --define "_sourcedir $(pwd)" --define "_specdir $(pwd)" \
+           --define "_builddir $(pwd)" --define "_srcrpmdir $(pwd)" \
+           --define "_rpmdir $(pwd)" --nodeps -bs ${spec}.spec
+
+Build the binary from the SRPM
+
+$ rpmbuild --with openj9 --define 'vers_arch s390x' \
+           --define "_sourcedir $(pwd)" --define "_specdir $(pwd)" \
+           --define "_builddir $(pwd)" --define "_srcrpmdir $(pwd)" \
+           --define "_rpmdir $(pwd)" --target "s390x" --rebuild *.src.rpm
+
+
+OpenJ9 on host architecture:
+----------------------------
+
+In order to produce an RPM with the OpenJ9 JVM on the host architecture, x86_64,
+consider this example:
+
+$ spec=$(pwd)/temurin-jdk-11.spec
+$ mkdir openj9_x86_64
+$ pushd openj9_x86_64
+$ spectool --define '_with_openj9 --with-openj9' \
+           --gf ${spec}.spec
+
+Currently fails due to typo (uppercase 'U') in sha256.txt files
+
+$ sha256sum -c *.sha256.txt
+
+Create an SRPM
+
+$ rpmbuild --with openj9 \
+           --define "_sourcedir $(pwd)" --define "_specdir $(pwd)" \
+           --define "_builddir $(pwd)" --define "_srcrpmdir $(pwd)" \
+           --define "_rpmdir $(pwd)" --nodeps -bs ${spec}.spec
+
+Build the binary from the SRPM
+
+$ rpmbuild --with openj9 \
+           --define "_sourcedir $(pwd)" --define "_specdir $(pwd)" \
+           --define "_builddir $(pwd)" --define "_srcrpmdir $(pwd)" \
+           --define "_rpmdir $(pwd)" --rebuild *.src.rpm


### PR DESCRIPTION
I've done some experiments with this initial RPM work and came up with these suggestions. A few things:

- Get rid of `%{version}` shadowing macro as in a spec %{version} will be defined after the `Version: 1.2.3` declaration. Same with `%{release}`. This is just asking for trouble.
- Use global over define
- Use variables to construct the download URL for `Source0` and `Source1`. This can then be fed to `spectool` so as to download the sources and - optionally - perform the checksum verification.
- Use `%setup` macro instead of hand-crafted tarball extraction logic. Maybe I've missed something, but it seemed simpler.
- Use `--with/without openj9` spec-file conditional for HotSpot vs. OpenJ9 selection.
- Make java-XX-YY virtual provides configurable based on the JVM (java-11-openj9 for, well openj9, and java-11-openjdk, for hotspot)

This also includes a README so as to illustrate how this might be working. After this patch, producing an SRPM which can then be rebuilt somewhere else via `rpmbuild --rebuild` should be trivial.

For an update, all that needs changing would be values for `upstream_version`, `openj9_version` and `spec_version`. `spec_version` could probably be derived from `upstream_version` going forward.

Thoughts?